### PR TITLE
Changing css for the menu

### DIFF
--- a/src/main/webapp/resources/css/style.css
+++ b/src/main/webapp/resources/css/style.css
@@ -1955,8 +1955,10 @@ textarea:focus {
 /* Level 0 */
 .menu {
     position: relative;
+    display: table;
     margin-bottom: 30px;
     padding: 0 4px;
+    width: 100% !important;
     /*
     border-radius: 4px;
     -webkit-box-shadow: inset 0 0 1px #a4a4a4, inset 0 -2px 0 #a4a4a4, 0 3px 3px -1px rgba(0,0,0,0.2);
@@ -1972,9 +1974,14 @@ textarea:focus {
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f5f5f5', endColorstr='#eeeeee',GradientType=0 );
     */
 }
+
 .ie8 .menu {filter:none; background: #eee;}  /* IE8 understands dropdown feature only without gradient */
 
-.menu > li {float:left; position: relative;}
+.menu > li {  
+	display: table-cell;
+    width: auto;
+    position: relative;
+}
 
 .menu > li a {
     display: block;
@@ -2004,18 +2011,15 @@ textarea:focus {
 
 /* Level 1+ */
 .menu ul {
-    position: absolute;
-    top: -9999px;
-    left: -9999px;
+    display:none;
     z-index: 9499;
-    width:100%;
     min-width: 160px;
     border-radius: 4px;
+    position:absolute;
 }
 .menu > li:hover > ul,
 .menu > li.hover > ul {
-    top: 48px;
-    left: 0;
+    display:block;
     padding-top: 2px;
 }
 .menu ul li {


### PR DESCRIPTION
Changed css for the top menu of the website. 
The menu is now a table, <li>'s are the cells inside that are automatically distributed into the whole row.
After this, the logo can be put to the left also.

However, this change probably breaks the mobile version, so that would be needed to be figured out.
BEFORE: 
![BEFORE](http://oi59.tinypic.com/3310o74.jpg)
AFTER:
![AFTER](http://oi57.tinypic.com/dzza6p.jpg)
